### PR TITLE
Update rest_response.rb

### DIFF
--- a/lib/survey_gizmo/rest_response.rb
+++ b/lib/survey_gizmo/rest_response.rb
@@ -17,10 +17,7 @@ class RestResponse
     return unless data
 
     # Handle really crappy [] notation in SG API, so far just in SurveyResponse
-    (data.is_a?(Array) ? data : [data]).each do |datum|
-      # Fix for when SG API returns [null] as data
-      next if dataum.is_a?(NilClass)
-      
+    Array(data).compact.each do |datum|
       unless datum['datesubmitted'].blank?
         # SurveyGizmo returns date information in EST but does not provide time zone information.
         # See https://surveygizmov4.helpgizmo.com/help/article/link/date-and-time-submitted

--- a/lib/survey_gizmo/rest_response.rb
+++ b/lib/survey_gizmo/rest_response.rb
@@ -18,6 +18,9 @@ class RestResponse
 
     # Handle really crappy [] notation in SG API, so far just in SurveyResponse
     (data.is_a?(Array) ? data : [data]).each do |datum|
+      # Fix for when SG API returns [null] as data
+      next if dataum.is_a?(NilClass)
+      
       unless datum['datesubmitted'].blank?
         # SurveyGizmo returns date information in EST but does not provide time zone information.
         # See https://surveygizmov4.helpgizmo.com/help/article/link/date-and-time-submitted


### PR DESCRIPTION
SG API returns this:
```JSON
{  
   "result_ok":true,
   "total_count":"0",
   "page":1,
   "total_pages":0,
   "results_per_page":50,
   "data":[  
      null
   ]
}
```
when requesting survey campaigns.

This causes the error `NoMethodError: undefined method '[]' for nil:NilClass` because `dataum` is `nil`