### PR TITLE
all_pages option for .all method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 # Retrieve the first page of your surveys
 surveys = SurveyGizmo::API::Survey.all
 # Retrieve ALL your surveys (handle pagination for you)
-surveys = SurveyGizmo::API::Survey.everything
+surveys = SurveyGizmo::API::Survey.all(all_pages: true)
 
 # Retrieve the survey with id: 12345
 survey = SurveyGizmo::API::Survey.first(id: 12345)

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ SurveyGizmo.configure do |config|
   config.api_version = 'v4'
 end
 
-# Retrieve all your surveys
+# Retrieve the first page of your surveys
 surveys = SurveyGizmo::API::Survey.all
+# Retrieve ALL your surveys (handle pagination for you)
+surveys = SurveyGizmo::API::Survey.everything
 
 # Retrieve the survey with id: 12345
 survey = SurveyGizmo::API::Survey.first(id: 12345)

--- a/lib/survey_gizmo/multilingual_title.rb
+++ b/lib/survey_gizmo/multilingual_title.rb
@@ -1,3 +1,6 @@
+# SurveyGizmo has a bad habit of returning titles in different formats when one is
+# requesting all surveys vs. an individual survey.
+
 module SurveyGizmo
   module MultilingualTitle
     extend ActiveSupport::Concern

--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -20,9 +20,19 @@ module SurveyGizmo
     module ClassMethods
       # Get an array of resources
       def all(conditions = {}, filters = {})
+        fail 'The :all_pages condition and the :page filter are mutually exclusive' if filters[:page] && conditions[:all_pages]
+
+        all_pages = conditions.delete(:all_pages)
         filters[:resultsperpage] = SurveyGizmo.configuration.results_per_page unless filters[:resultsperpage]
+
         response = RestResponse.new(SurveyGizmo.get(handle_route(:create, conditions) + convert_filters_into_query_string(filters)))
         collection = response.data.map { |datum| datum.is_a?(Hash) ? self.new(datum) : datum }
+
+        while all_pages && response.current_page < response.total_pages
+          paged_filter = convert_filters_into_query_string(filters.merge(page: response.current_page + 1))
+          response = RestResponse.new(SurveyGizmo.get(handle_route(:create, conditions) + paged_filter))
+          collection += response.data.map { |datum| datum.is_a?(Hash) ? self.new(datum) : datum }
+        end
 
         # Add in the properties from the conditions hash because many of the important ones (like survey_id) are
         # not often part of the SurveyGizmo returned data
@@ -37,19 +47,6 @@ module SurveyGizmo
         # returned in one request.
         if self == SurveyGizmo::API::Question
           collection += collection.map { |question| question.sub_questions }.flatten
-        end
-
-        collection
-      end
-
-      # Do the pagination for you
-      def everything(conditions = {}, filters = {})
-        page = 1
-        collection = []
-
-        while !(request_collection = all(conditions, filters.merge(page: page))).empty?
-          collection += request_collection
-          page += 1
         end
 
         collection

--- a/lib/survey_gizmo/rest_response.rb
+++ b/lib/survey_gizmo/rest_response.rb
@@ -48,12 +48,20 @@ class RestResponse
 
   # The parsed JSON data of the response
   def data
-    @_data ||= @parsed_response['data']
+    @parsed_response['data']
   end
 
   # The error message if there is one
   def message
-    @_message ||= @parsed_response['message']
+    @parsed_response['message']
+  end
+
+  def current_page
+    @parsed_response['page']
+  end
+
+  def total_pages
+    @parsed_response['total_pages']
   end
 
   private

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '4.0.2'
+  VERSION = '4.1.0'
 end


### PR DESCRIPTION
@jarthod 
2 changes here - 

1. enable configuration of the `resultsperpage` parameter.  Setting this higher might help with some people's timeout issues, depending on how they are making requests.  I left the default as the SG default.

2. an optional condition `:all_pages` for the `.all` method so that `SurveyGizmo::API::Survey.all(all_pages: true)` really gives you all your surveys (we just hit a bug where we went over 50 active surveys and didn't realize `SurveyGizmo::API::Survey.all` wasn't returning them all)

Open to suggestions as to whether or not the `conditions` is the place for this... unfortunately i feel like the _really_ right answer is break the method signature for `.all` and `.first` so that there's just one hash parameter, instead of both `conditions` and `filters` - that's some ugly legacy cruft.