### PR TITLE
Collapse .all and .first api method signatures to single hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Currently supports SurveyGizmo API **v4** (default) and **v3**.
 
 ## Versions
 
+### Major Changes in 5.x
+
+* BREAKING CHANGE: Method signatures for .all and .first have changed - now it's just one hash.
+
 ### Major Changes in 4.x
 
 * BREAKING CHANGE: There is no more error tracking.  If the API gives an error or bad response, an exception will be raised.
@@ -71,13 +75,11 @@ question.save
 question.destroy
 
 # Retrieving SurveyResponses for a given survey.
-# Note that because both options are hashes, you need to enclose them both in
-# braces to page successfully!
-responses = SurveyGizmo::API::Response.all({ survey_id: survey.id }, { page: 1 })
+responses = SurveyGizmo::API::Response.all(survey_id: survey.id, page: 1)
 
 # Retrieving page 2 of non test data SurveyResponses
-filters  = { page: 2, filters: [{ field: 'istestdata', operator: '<>', value: 1 }] }
-responses = SurveyGizmo::API::Response.all({ survey_id: survey_id }, filters)
+conditions = { survey_id: survey_id, page: 2, filters: [{ field: 'istestdata', operator: '<>', value: 1 }] }
+responses = SurveyGizmo::API::Response.all(conditions)
 ```
 
 ## On API Timeouts

--- a/README.md
+++ b/README.md
@@ -74,12 +74,16 @@ question.save
 # Destroy a question
 question.destroy
 
-# Retrieving SurveyResponses for a given survey.
-responses = SurveyGizmo::API::Response.all(survey_id: survey.id, page: 1)
-
-# Retrieving page 2 of non test data SurveyResponses
-conditions = { survey_id: survey_id, page: 2, filters: [{ field: 'istestdata', operator: '<>', value: 1 }] }
-responses = SurveyGizmo::API::Response.all(conditions)
+# Retrieve 2nd page of SurveyResponses for a given survey.
+responses = SurveyGizmo::API::Response.all(survey_id: survey.id, page: 2)
+# Retrieve all responses for a given survey.
+responses = SurveyGizmo::API::Response.all(all_pages: true, survey_id: survey.id)
+# Retrieving page 3 of non test data SurveyResponses
+responses = SurveyGizmo::API::Response.all(
+  survey_id: survey_id,
+  page: 3,
+  filters: [{ field: 'istestdata', operator: '<>', value: 1 }]
+)
 ```
 
 ## On API Timeouts

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ SurveyGizmo.configure do |config|
 
   # api_version defaults to v4, but you can probably set to v3 safely if you suspect a bug in v4
   config.api_version = 'v4'
+
+  # Setting the results_per_page too high can cause SurveyGizmo to start throwing timeouts
+  # The SurveyGizmo default is 50.
+  config.results_per_page = 100
 end
 
 # Retrieve the first page of your surveys

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 # Retrieve the first page of your surveys
 surveys = SurveyGizmo::API::Survey.all
 # Retrieve ALL your surveys (handle pagination for you)
-surveys = SurveyGizmo::API::Survey.everything
+surveys = SurveyGizmo::API::Survey.all(all_pages: true)
 
 # Retrieve the survey with id: 12345
 survey = SurveyGizmo::API::Survey.first(id: 12345)

--- a/README.md
+++ b/README.md
@@ -40,11 +40,10 @@ SurveyGizmo.configure do |config|
   config.user = 'still_tippin@woodgraingrip.com'
   config.password = 'it_takes_grindin_to_be_a_king'
 
-  # api_version defaults to v4, but you can probably set to v3 safely if you suspect a bug in v4
+  # Optional - Defaults to v4, but you can probably set to v3 safely if you suspect a bug in v4
   config.api_version = 'v4'
 
-  # Setting the results_per_page too high can cause SurveyGizmo to start throwing timeouts
-  # The SurveyGizmo default is 50.
+  # Optional - Defaults to 50, maximum 500. Setting too high may cause SurveyGizmo to start throwing timeouts.
   config.results_per_page = 100
 end
 
@@ -75,12 +74,12 @@ question.save
 question.destroy
 
 # Retrieve 2nd page of SurveyResponses for a given survey.
-responses = SurveyGizmo::API::Response.all(survey_id: survey.id, page: 2)
+responses = SurveyGizmo::API::Response.all(survey_id: 12345, page: 2)
 # Retrieve all responses for a given survey.
-responses = SurveyGizmo::API::Response.all(all_pages: true, survey_id: survey.id)
+responses = SurveyGizmo::API::Response.all(all_pages: true, survey_id: 12345)
 # Retrieving page 3 of non test data SurveyResponses
 responses = SurveyGizmo::API::Response.all(
-  survey_id: survey_id,
+  survey_id: 12345,
   page: 3,
   filters: [{ field: 'istestdata', operator: '<>', value: 1 }]
 )

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ Currently supports SurveyGizmo API **v4** (default) and **v3**.
 
 ## Versions
 
-### Major Changes in 5.x
-
-* BREAKING CHANGE: Method signatures for .all and .first have changed - now it's just one hash.
-
 ### Major Changes in 4.x
 
 * BREAKING CHANGE: There is no more error tracking.  If the API gives an error or bad response, an exception will be raised.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ SurveyGizmo.configure do |config|
   config.api_version = 'v4'
 end
 
-# Retrieve all your surveys
+# Retrieve the first page of your surveys
 surveys = SurveyGizmo::API::Survey.all
+# Retrieve ALL your surveys (handle pagination for you)
+surveys = SurveyGizmo::API::Survey.everything
 
 # Retrieve the survey with id: 12345
 survey = SurveyGizmo::API::Survey.first(id: 12345)

--- a/lib/survey_gizmo/api/survey.rb
+++ b/lib/survey_gizmo/api/survey.rb
@@ -29,7 +29,7 @@ module SurveyGizmo; module API
     end
 
     def pages
-      @pages ||= SurveyGizmo::API::Page.all(survey_id: id)
+      @pages ||= SurveyGizmo::API::Page.all(survey_id: id, all_responses: true)
     end
 
     # Sub question handling is in resource.rb.  It should probably be here instead but if it gets moved here
@@ -59,8 +59,8 @@ module SurveyGizmo; module API
       responses.size > 0
     end
 
-    # As of 2015-08-07, when you request data on multiple surveys from /survey, the team
-    # variable comes back as "0".  If you request one survey at a time from /survey/{id}, it works correctly.
+    # As of 2015-08-07, when you request data on multiple surveys from /survey, the team variable comes
+    # back as "0".  If you request one survey at a time from /survey/{id}, it is populated correctly.
     def teams
       @individual_survey ||= SurveyGizmo::API::Survey.first(id: self.id)
       @individual_survey.team

--- a/lib/survey_gizmo/api/survey.rb
+++ b/lib/survey_gizmo/api/survey.rb
@@ -55,7 +55,7 @@ module SurveyGizmo; module API
         operator: '>=',
         value: time.in_time_zone('Eastern Time (US & Canada)').strftime('%Y-%m-%d %H:%M:%S')
       }]
-      responses = SurveyGizmo::API::Response.all({ survey_id: self.id }, { page: 1, filters: filters })
+      responses = SurveyGizmo::API::Response.all(survey_id: self.id, page: 1, filters: filters)
       responses.size > 0
     end
 

--- a/lib/survey_gizmo/api/survey_campaign.rb
+++ b/lib/survey_gizmo/api/survey_campaign.rb
@@ -23,8 +23,8 @@ module SurveyGizmo; module API
     attribute :surveycampaign,  Integer
     attribute :copy,            Boolean
 
-    route '/survey/:survey_id/surveycampaign/:id', :via => [:get, :update, :delete]
-    route '/survey/:survey_id/surveycampaign', :via => :create
+    route '/survey/:survey_id/surveycampaign/:id', via: [:get, :update, :delete]
+    route '/survey/:survey_id/surveycampaign', via: :create
 
     def to_param_options
       { id: self.id, survey_id: self.survey_id }

--- a/lib/survey_gizmo/multilingual_title.rb
+++ b/lib/survey_gizmo/multilingual_title.rb
@@ -1,3 +1,6 @@
+# SurveyGizmo has a bad habit of returning titles in different formats when one is
+# requesting all surveys vs. an individual survey.
+
 module SurveyGizmo
   module MultilingualTitle
     extend ActiveSupport::Concern

--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -32,10 +32,7 @@ module SurveyGizmo
       # Set all_pages: true if you want the gem to page through all the available responses
       def all(conditions = {}, _deprecated_filters = {})
         fail ':all_pages and :page are mutually exclusive conditions' if conditions[:page] && conditions[:all_pages]
-        unless _deprecated_filters.empty?
-          $stderr.puts('Use of the 2nd hash parameter is deprecated.')
-          conditions.merge!(_deprecated_filters)
-        end
+        merge_params!(conditions, _deprecated_filters)
 
         all_pages = conditions.delete(:all_pages)
         conditions[:resultsperpage] = SurveyGizmo.configuration.results_per_page unless conditions[:resultsperpage]
@@ -70,10 +67,7 @@ module SurveyGizmo
 
       # Retrieve a single resource.  See usage comment on .all
       def first(conditions, _deprecated_filters = {})
-        unless _deprecated_filters.empty?
-          $stderr.puts('Use of the 2nd hash parameter is deprecated.')
-          conditions.merge!(_deprecated_filters)
-        end
+        merge_params!(conditions, _deprecated_filters)
 
         response = RestResponse.new(SurveyGizmo.get(handle_route!(:get, conditions) + convert_filters_into_query_string(conditions)))
         # Add in the properties from the conditions hash because many of the important ones (like survey_id) are
@@ -115,6 +109,8 @@ module SurveyGizmo
         end
       end
 
+      private
+
       # Convert a [Hash] of internal surveygizmo style filters into a query string
       # See: http://apihelp.surveygizmo.com/help/article/link/filters
       def convert_filters_into_query_string(filters = {})
@@ -132,6 +128,13 @@ module SurveyGizmo
         uri = Addressable::URI.new
         uri.query_values = params.merge(filters)
         "?#{uri.query}"
+      end
+
+      def merge_params!(conditions, _deprecated_filters)
+        unless _deprecated_filters.empty?
+          $stderr.puts('Use of the 2nd hash parameter is deprecated.')
+          conditions.merge!(_deprecated_filters)
+        end
       end
     end
 

--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -106,24 +106,22 @@ module SurveyGizmo
         end
       end
 
-      # Convert a [Hash] of filters into a query string
+      # Convert a [Hash] of internal surveygizmo style filters into a query string
+      # See: http://apihelp.surveygizmo.com/help/article/link/filters
       def convert_filters_into_query_string(filters = {})
         return '' unless filters && filters.size > 0
 
-        output_filters = filters[:filters] || []
-        filter_hash = {}
-        output_filters.each_with_index do |filter,i|
-          filter_hash.merge!(
-            "filter[field][#{i}]".to_sym    => "#{filter[:field]}",
-            "filter[operator][#{i}]".to_sym => "#{filter[:operator]}",
-            "filter[value][#{i}]".to_sym    => "#{filter[:value]}",
-          )
+        params = {}
+        (filters.delete(:filters) || []).each_with_index do |filter, i|
+          fail 'Bad filter params!' unless [:field, :operator, :value].all? { |k| filter[k] }
+
+          params["filter[field][#{i}]".to_sym]    = "#{filter[:field]}"
+          params["filter[operator][#{i}]".to_sym] = "#{filter[:operator]}"
+          params["filter[value][#{i}]".to_sym]    = "#{filter[:value]}"
         end
-        simple_filters = filters.reject { |k,v| k == :filters }
-        filter_hash.merge!(simple_filters)
 
         uri = Addressable::URI.new
-        uri.query_values = filter_hash
+        uri.query_values = params.merge(filters)
         "?#{uri.query}"
       end
     end

--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -30,8 +30,12 @@ module SurveyGizmo
       # filter[field][0]=istestdata&filter[operator][0]=<>&filter[value][0]=1
       #
       # Set all_pages: true if you want the gem to page through all the available responses
-      def all(conditions = {})
+      def all(conditions = {}, _deprecated_filters = {})
         fail ':all_pages and :page are mutually exclusive conditions' if conditions[:page] && conditions[:all_pages]
+        unless _deprecated_filters.empty?
+          $stderr.puts('Use of the 2nd hash parameter is deprecated.')
+          conditions.merge!(_deprecated_filters)
+        end
 
         all_pages = conditions.delete(:all_pages)
         conditions[:resultsperpage] = SurveyGizmo.configuration.results_per_page unless conditions[:resultsperpage]
@@ -65,7 +69,12 @@ module SurveyGizmo
       end
 
       # Retrieve a single resource.  See usage comment on .all
-      def first(conditions)
+      def first(conditions, _deprecated_filters = {})
+        unless _deprecated_filters.empty?
+          $stderr.puts('Use of the 2nd hash parameter is deprecated.')
+          conditions.merge!(_deprecated_filters)
+        end
+
         response = RestResponse.new(SurveyGizmo.get(handle_route!(:get, conditions) + convert_filters_into_query_string(conditions)))
         # Add in the properties from the conditions hash because many of the important ones (like survey_id) are
         # not often part of the SurveyGizmo's returned data

--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -20,9 +20,19 @@ module SurveyGizmo
     module ClassMethods
       # Get an array of resources
       def all(conditions = {}, filters = {})
+        fail 'The :all_pages condition and the :page filter are mutually exclusive' if filters[:page] && conditions[:all_pages]
+
+        all_pages = conditions.delete(:all_pages)
         filters[:resultsperpage] = SurveyGizmo.configuration.results_per_page unless filters[:resultsperpage]
+
         response = RestResponse.new(SurveyGizmo.get(handle_route(:create, conditions) + convert_filters_into_query_string(filters)))
         collection = response.data.map { |datum| datum.is_a?(Hash) ? self.new(datum) : datum }
+
+        while all_pages && response.current_page < response.total_pages
+          paged_filter = convert_filters_into_query_string(filters.merge(page: response.current_page + 1))
+          response = RestResponse.new(SurveyGizmo.get(handle_route(:create, conditions) + paged_filter))
+          collection += response.data.map { |datum| datum.is_a?(Hash) ? self.new(datum) : datum }
+        end
 
         # Add in the properties from the conditions hash because many of the important ones (like survey_id) are
         # not often part of the SurveyGizmo returned data
@@ -37,19 +47,6 @@ module SurveyGizmo
         # returned in one request.
         if self == SurveyGizmo::API::Question
           collection += collection.map { |question| question.sub_questions }.flatten
-        end
-
-        collection
-      end
-
-      # Do the pagination for you
-      def everything(conditions = {}, filters = {})
-        page = 1
-        collection = []
-
-        while !(request_collection = all(conditions, filters.merge(page: page))).empty?
-          collection += request_collection
-          page += 1
         end
 
         collection

--- a/lib/survey_gizmo/rest_response.rb
+++ b/lib/survey_gizmo/rest_response.rb
@@ -48,12 +48,20 @@ class RestResponse
 
   # The parsed JSON data of the response
   def data
-    @_data ||= @parsed_response['data']
+    @parsed_response['data']
   end
 
   # The error message if there is one
   def message
-    @_message ||= @parsed_response['message']
+    @parsed_response['message']
+  end
+
+  def current_page
+    @parsed_response['page']
+  end
+
+  def total_pages
+    @parsed_response['total_pages']
   end
 
   private

--- a/lib/survey_gizmo/rest_response.rb
+++ b/lib/survey_gizmo/rest_response.rb
@@ -4,16 +4,16 @@ class RestResponse
   attr_accessor :raw_response
   attr_accessor :parsed_response
 
-  def initialize(rest_response)
-    @raw_response = rest_response
-    @parsed_response = rest_response.parsed_response
+  def initialize(http_response)
+    @raw_response = http_response
+    @parsed_response = http_response.parsed_response
 
     if ENV['GIZMO_DEBUG']
       ap 'Parsed SurveyGizmo Response:'
       ap @parsed_response
     end
 
-    fail "Bad response: #{rest_response.inspect}" unless @parsed_response['result_ok'] && @parsed_response['result_ok'].to_s.downcase == 'true'
+    fail "Bad response: #{http_response.inspect}" unless @parsed_response['result_ok'] && @parsed_response['result_ok'].to_s.downcase == 'true'
     return unless data
 
     # Handle really crappy [] notation in SG API, so far just in SurveyResponse

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '4.1.0'
+  VERSION = '5.0.0'
 end

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '5.0.0'
+  VERSION = '4.2.0'
 end

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '4.2.0'
+  VERSION = '4.1.1'
 end

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,4 +1,4 @@
 module SurveyGizmo
   # TODO: When bumping to 5.0, remove the deprecated parameters for Resource.all and Resource.first
-  VERSION = '4.1.1'
+  VERSION = '4.1.0'
 end

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,4 @@
 module SurveyGizmo
+  # TODO: When bumping to 5.0, remove the deprecated parameters for Resource.all and Resource.first
   VERSION = '4.1.1'
 end

--- a/lib/survey_gizmo/version.rb
+++ b/lib/survey_gizmo/version.rb
@@ -1,3 +1,3 @@
 module SurveyGizmo
-  VERSION = '4.0.2'
+  VERSION = '4.1.0'
 end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -72,7 +72,7 @@ describe 'Survey Gizmo Resource' do
 
   describe SurveyGizmo::API::Question do
     let(:base_params)       { {survey_id: 1234, page_id: 1} }
-    let(:create_attributes) { base_params.merge(title: 'Spec Question', type: 'radio', properties: {'required' => true, 'option_sort' => false}) }
+    let(:create_attributes) { base_params.merge(title: 'Spec Question', type: 'radio') }
     let(:update_attributes) { base_params.merge(title: 'Updated') }
     let(:first_params)      { base_params.merge(id: 1) }
     let(:get_attributes)    { create_attributes.merge(id: 1) }
@@ -108,6 +108,7 @@ describe 'Survey Gizmo Resource' do
     context 'with subquestions' do
       let(:parent_id) { 33 }
       let(:question_with_subquestions) { described_class.new(id: parent_id, survey_id: 1234, sub_question_skus: [1, 2])}
+
       it 'should have 2 subquestions and they should have the right parent question' do
         stub_request(:get, /#{@base}/).to_return(json_response(true, get_attributes))
         expect(question_with_subquestions.sub_questions.size).to eq(2)

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -41,11 +41,11 @@ describe 'Survey Gizmo Resource' do
       let(:filters) { { page: page, filters: [{ field: 'istestdata', operator: '<>', value: 1 }] } }
 
       it 'should generate the correct page request' do
-        expect(SurveyGizmoSpec::ResourceTest.convert_filters_into_query_string(page: page)).to eq("?page=#{page}")
+        expect(SurveyGizmoSpec::ResourceTest.send(:convert_filters_into_query_string, { page: page })).to eq("?page=#{page}")
       end
 
       it 'should generate the correct filter fragment' do
-        expect(SurveyGizmoSpec::ResourceTest.convert_filters_into_query_string(filters)).to eq("?filter%5Bfield%5D%5B0%5D=istestdata&filter%5Boperator%5D%5B0%5D=%3C%3E&filter%5Bvalue%5D%5B0%5D=1&page=#{page}")
+        expect(SurveyGizmoSpec::ResourceTest.send(:convert_filters_into_query_string, filters)).to eq("?filter%5Bfield%5D%5B0%5D=istestdata&filter%5Boperator%5D%5B0%5D=%3C%3E&filter%5Bvalue%5D%5B0%5D=1&page=#{page}")
       end
     end
   end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -72,10 +72,10 @@ describe 'Survey Gizmo Resource' do
 
   describe SurveyGizmo::API::Question do
     let(:base_params)       { {survey_id: 1234, page_id: 1} }
-    let(:create_attributes) { base_params.merge(title: 'Spec Question', type: 'radio') }
+    let(:create_attributes) { base_params.merge(title: 'Spec Question', type: 'radio', properties: { 'required' => true, 'option_sort' => false }) }
     let(:update_attributes) { base_params.merge(title: 'Updated') }
     let(:first_params)      { base_params.merge(id: 1) }
-    let(:get_attributes)    { create_attributes.merge(id: 1) }
+    let(:get_attributes)    { create_attributes.merge(id: 1).reject { |k, v| k == :properties } }
     let(:uri_paths) {
       { :get =>    '/survey/1234/surveyquestion/1',
         :create => '/survey/1234/surveypage/1/surveyquestion',
@@ -96,7 +96,7 @@ describe 'Survey Gizmo Resource' do
     end
 
     it 'should have no subquestions' do
-      expect(described_class.new().sub_questions).to eq([])
+      expect(described_class.new.sub_questions).to eq([])
     end
 
     it 'should find the survey' do
@@ -107,7 +107,7 @@ describe 'Survey Gizmo Resource' do
 
     context 'with subquestions' do
       let(:parent_id) { 33 }
-      let(:question_with_subquestions) { described_class.new(id: parent_id, survey_id: 1234, sub_question_skus: [1, 2])}
+      let(:question_with_subquestions) { described_class.new(id: parent_id, survey_id: 1234, sub_question_skus: [1, 2]) }
 
       it 'should have 2 subquestions and they should have the right parent question' do
         stub_request(:get, /#{@base}/).to_return(json_response(true, get_attributes))


### PR DESCRIPTION
@jarthod 
This supersedes https://github.com/RipTheJacker/survey-gizmo-ruby/pull/42 but I'm not ready to merge this yet.  Collapsing the method signatures makes everything a lot less user error prone and generally better but is also a majorly breaking change with everyday usage that I have not tested yet.

Other PR should be ready for merge and is only a minor version bump.  Not sure when I will finish this but heads up and feedback appreciated.