### PR TITLE
[WIP] Fix SurveyGizmo::API::Question#sub_questions

### DIFF
--- a/lib/survey_gizmo/api/question.rb
+++ b/lib/survey_gizmo/api/question.rb
@@ -34,7 +34,11 @@ module SurveyGizmo; module API
     end
 
     def sub_questions
-      @sub_questions ||= sub_question_skus.map { |subquestion_shortname, subquestion_id| Question.first(survey_id: survey_id, id: subquestion_id) }
+      # As of 2015-12-23, the sub_question_skus attribute can either contain an array of integers if no shortname (alias)
+      # was set for any question, or an array of [String, Integer] with the String corresponding to the subquestion
+      # shortname and the integer corresponding to the subquestion id if at least one shortname was set.
+      sub_question_skus_array = sub_question_skus.map { |sub_question_sku| sub_question_sku.is_a?(Array) ? sub_question_sku[1] : sub_question_sku }
+      @sub_questions ||= sub_question_skus_array.map { |subquestion_id| Question.first(survey_id: survey_id, id: subquestion_id) }
                                           .each { |subquestion| subquestion.parent_question_id = id  }
     end
 

--- a/lib/survey_gizmo/api/question.rb
+++ b/lib/survey_gizmo/api/question.rb
@@ -34,7 +34,7 @@ module SurveyGizmo; module API
     end
 
     def sub_questions
-      @sub_questions ||= sub_question_skus.map { |subquestion_id| Question.first(survey_id: survey_id, id: subquestion_id) }
+      @sub_questions ||= sub_question_skus.map { |subquestion_shortname, subquestion_id| Question.first(survey_id: survey_id, id: subquestion_id) }
                                           .each { |subquestion| subquestion.parent_question_id = id  }
     end
 

--- a/lib/survey_gizmo/api/question.rb
+++ b/lib/survey_gizmo/api/question.rb
@@ -37,7 +37,7 @@ module SurveyGizmo; module API
       # As of 2015-12-23, the sub_question_skus attribute can either contain an array of integers if no shortname (alias)
       # was set for any question, or an array of [String, Integer] with the String corresponding to the subquestion
       # shortname and the integer corresponding to the subquestion id if at least one shortname was set.
-      sub_question_skus_array = sub_question_skus.map { |sub_question_sku| sub_question_sku.is_a?(Array) ? sub_question_sku[1] : sub_question_sku }
+      sub_question_skus_array = sub_question_skus.map { |sku| sku.is_a?(Array) ? sku[1] : sku }
       @sub_questions ||= sub_question_skus_array.map { |subquestion_id| Question.first(survey_id: survey_id, id: subquestion_id) }
                                           .each { |subquestion| subquestion.parent_question_id = id  }
     end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -116,6 +116,18 @@ describe 'Survey Gizmo Resource' do
         question_with_subquestions.sub_questions.first.parent_question
         a_request(:get, /#{@base}\/survey\/1234\/surveyquestion\/#{parent_id}/).should have_been_made
       end
+
+      context 'and shortname' do
+        let(:question_with_subquestions) { described_class.new(id: parent_id, survey_id: 1234, sub_question_skus: [["0", 6], ["foo", 8]]) }
+
+        it 'should have 2 subquestions and they should have the right parent question' do
+          stub_request(:get, /#{@base}/).to_return(json_response(true, get_attributes))
+          expect(question_with_subquestions.sub_questions.size).to eq(2)
+
+          question_with_subquestions.sub_questions.first.parent_question
+          a_request(:get, /#{@base}\/survey\/1234\/surveyquestion\/#{parent_id}/).should have_been_made
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Hi,

I think I noticed a small problem in SurveyGizmo::API::Question#sub_questions but I'd like to have your input before continuing the PR and writing some specs.

When I try to fetch all the questions of a survey containing sub questions with the following code:
```ruby
SurveyGizmo::API::Question.all(survey_id: my_id, page_id: 1).inspect
```
it fails with this error:
```
/home/fchaynes/.rbenv/versions/2.1.7/lib/ruby/2.1.0/uri/common.rb:176:in `split': bad URI(is not URI?): /survey/1234567/surveyquestion/["0", 6] (URI::InvalidURIError)
	from /home/fchaynes/.rbenv/versions/2.1.7/lib/ruby/2.1.0/uri/common.rb:211:in `parse'
	from /home/fchaynes/.rbenv/versions/2.1.7/lib/ruby/2.1.0/uri/common.rb:747:in `parse'
	from /home/fchaynes/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/httparty-0.13.7/lib/httparty/request.rb:53:in `path='
	from /home/fchaynes/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/httparty-0.13.7/lib/httparty/request.rb:43:in `initialize'
	from /home/fchaynes/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/httparty-0.13.7/lib/httparty.rb:545:in `new'
	from /home/fchaynes/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/httparty-0.13.7/lib/httparty.rb:545:in `perform_request'
	from /home/fchaynes/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/httparty-0.13.7/lib/httparty.rb:476:in `get'
	from /home/fchaynes/Projects/github/survey-gizmo-ruby/lib/survey_gizmo/resource.rb:73:in `first'
	from /home/fchaynes/Projects/github/survey-gizmo-ruby/lib/survey_gizmo/api/question.rb:37:in `block in sub_questions'
	from /home/fchaynes/Projects/github/survey-gizmo-ruby/lib/survey_gizmo/api/question.rb:37:in `map'
	from /home/fchaynes/Projects/github/survey-gizmo-ruby/lib/survey_gizmo/api/question.rb:37:in `sub_questions'
	from /home/fchaynes/Projects/github/survey-gizmo-ruby/lib/survey_gizmo/resource.rb:62:in `block in all'
	from /home/fchaynes/Projects/github/survey-gizmo-ruby/lib/survey_gizmo/resource.rb:62:in `map'
	from /home/fchaynes/Projects/github/survey-gizmo-ruby/lib/survey_gizmo/resource.rb:62:in `all'
	from sg_gem.rb:9:in `<main>'
```

On the [SurveyGizmo API documentation] (http://apihelp.surveygizmo.com/help/article/link/surveyquestion-returned-fields) they say that `sub_question_skus` is a number but when I enable the debug mode in the gem, here's what I actually get (I removed irrelevant informations for clarity):
```ruby
"Parsed SurveyGizmo Response:"
{
           "result_ok" => true,
         "total_count" => 1,
                "page" => 1,
         "total_pages" => 1,
    "results_per_page" => 1,
                "data" => [
        [0] {
                           "id" => 5,
                        "_type" => "SurveyQuestion",
                     "_subtype" => "group",
            [...]
            "sub_question_skus" => {
                                    "0" => 6,
                                    "1" => 8,
                "customer_satisfaction" => 9
            }
        }
    ]
}
```

so it seems to fail because we're not receiving just the question id but a hash with the sub question shortname for the key and the id for the value. BTW, it's the same thing with the v3.

Have you ever experienced this problem? Am I misunderstanding something or is the documentation incorrect?