### PR TITLE
Answer parsing feature, automatic paging, retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ responses = SurveyGizmo::API::Response.all(
 # Note that this may not be a good idea for surveys with very large numbers of responses!
 responses = SurveyGizmo::API::Response.all(all_pages: true, survey_id: 12345)
 # If you want the gem to handle paging for you, use the :all_pages option and process your pages in a block
-SurveyGizmo::API::Response.all(all_pages: true, survey_id: 12345) do |responses|
-  responses.each { |r| process_response(r) }
+SurveyGizmo::API::Response.all(all_pages: true, survey_id: 12345) do |page_of_responses|
+  page_of_responses.each { |r| process_response(r) }
 end
 
 # Parse the wacky answer hash format into a more usable format.

--- a/lib/survey_gizmo/api/answer.rb
+++ b/lib/survey_gizmo/api/answer.rb
@@ -38,11 +38,8 @@ module SurveyGizmo
 
         @question_id = @question_id.to_i
         if @option_id
-          if @option_id.to_i == 0 && @option_id != '0'
-            fail "Bad option_id #{@option_id}!"
-          else
-            @option_id = @option_id.to_i
-          end
+          fail "Bad option_id #{@option_id}!" if @option_id.to_i == 0 && @option_id != '0'
+          @option_id = @option_id.to_i
         end
       end
 

--- a/lib/survey_gizmo/resource.rb
+++ b/lib/survey_gizmo/resource.rb
@@ -87,18 +87,19 @@ module SurveyGizmo
       end
 
       # Replaces the :page_id, :survey_id, etc strings defined in each model's URI routes with the
-      # values being passed in interpolation hash with the same keys.
-      def create_route(key, interpolation_hash)
+      # values being passed in the params hash with the same keys.
+      def create_route(key, params)
         path = @paths[key]
         fail "No routes defined for `#{key}` in #{name}" unless path
         fail "User/password hash not setup!" if SurveyGizmo.default_params.empty?
 
+        url_params = params.dup
         rest_path = path.gsub(/:(\w+)/) do |m|
-          raise SurveyGizmo::URLError, "Missing RESTful parameters in request: `#{m}`" unless interpolation_hash[$1.to_sym]
-          interpolation_hash[$1.to_sym]
+          fail SurveyGizmo::URLError, "Missing RESTful parameters in request: `#{m}`" unless url_params[$1.to_sym]
+          url_params.delete($1.to_sym)
         end
 
-        rest_path + filters_to_query_string(interpolation_hash)
+        rest_path + filters_to_query_string(url_params)
       end
 
       private


### PR DESCRIPTION
Replaces https://github.com/RipTheJacker/survey-gizmo-ruby/pull/48

`Answer` is its own model.

`SurveyGizmo::API::Klass.all(:all_pages)` works with a block to handle all paging automatically.

as per our earlier discussion, the default retry behavior is no retries.  

the reason i ended up adding some internal retry logic was because without it, the `:all_pages` loop is kind of useless - a simple timeout in the middle of pulling a million records would cause the data to be lost.

(that and it will solve a lot of annoying problems with SG rate limits)

Also contains merge of https://github.com/RipTheJacker/survey-gizmo-ruby/pull/47